### PR TITLE
MAYH-5709 replace -1 unconsumed/empty partition offset with 0

### DIFF
--- a/checks.d/burrow.py
+++ b/checks.d/burrow.py
@@ -149,6 +149,9 @@ class BurrowCheck(AgentCheck):
         """
         offsets = json.get("offsets")
         if offsets:
+            # for unconsumed or empty partitions, change an offset of -1 to 0 so the
+            # sum isn't affected by the number of empty partitions.
+            offsets = [max(offset, 0) for offset in offsets]
             self.gauge("kafka.%s.offsets.total" % offsets_type, sum(offsets), tags=tags)
             for partition_number, offset in enumerate(offsets):
                 new_tags = tags + ["partition:%s" % partition_number]


### PR DESCRIPTION
Empty partitions have an offset of `-1`, so the offsets for the partitions of a topic might be e.g. `[-1, -1, -1, -1, 1069, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]`.

The sum of the offsets can't be taken unless we pretend that they're at actually at offset `0`,

```
In [4]: sum([-1, -1, -1, -1, 1069, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1])
Out[4]: 1047

In [5]: sum([ 0,  0,  0,  0, 1069,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0])
Out[5]: 1069
```

(repost of packetloop/salt-master#555)