### PR TITLE
 * Dd v6 custom checks signature has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Metrics
 * `kafka.consumer.offsets.total` - Total offset of each consumer group
 
 *Lag*
-* `kafka.consumer.maxlag` - Maximum lag of each consumer group
 * `kafka.consumer.totallag` - Total lag of each consumer group
 * `kafka.consumer.partition_lag` - Lag of each partition of a consumer group
 

--- a/checks.d/burrow.py
+++ b/checks.d/burrow.py
@@ -54,7 +54,6 @@ class BurrowCheck(AgentCheck):
                 status = lag_json["status"]
                 consumer_tags = ["cluster:%s" % cluster, "consumer:%s" % consumer] + extra_tags
 
-                self.gauge("kafka.consumer.maxlag", status["maxlag"], tags=consumer_tags)
                 self.gauge("kafka.consumer.totallag", status["totallag"], tags=consumer_tags)
                 self._submit_lag_status("kafka.consumer.lag_status", status["status"], tags=consumer_tags)
 
@@ -84,9 +83,10 @@ class BurrowCheck(AgentCheck):
             self.gauge("%s.%s" % (metric_namespace, metric_name.lower()), value, tags=tags)
 
     def _submit_partition_lags(self, partition, tags):
-        lag = partition.get("end").get("lag")
-        timestamp = partition.get("end").get("timestamp") / 1000
-        self.gauge("kafka.consumer.partition_lag", lag, tags=tags, timestamp=timestamp)
+        end = partition.get("end")
+        if end is not None:
+            lag = end.get("lag")
+            self.gauge("kafka.consumer.partition_lag", lag, tags=tags)
 
     def _check_burrow(self, burrow_address, extra_tags):
         """


### PR DESCRIPTION
fix #8 

The function signature of the metric senders changed from for DD v6 agent:

gauge(self, metric, value, tags=None, hostname=None, device_name=None, timestamp=None)
to:

gauge(self, name, value, tags=None, hostname=None, device_name=None)

* maxlag returns a map and this breaks submission because it expects an
int or string and not map. Since this is not being used anywhere, just
remove this bit