### PR TITLE
Upgrade to Python 3

### DIFF
--- a/checks.d/burrow.py
+++ b/checks.d/burrow.py
@@ -1,5 +1,5 @@
 # stdlib
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 # 3rd Party
 import requests
@@ -79,7 +79,7 @@ class BurrowCheck(AgentCheck):
 
         burrow_status[status] = 1
 
-        for metric_name, value in burrow_status.iteritems():
+        for metric_name, value in burrow_status.items():
             self.gauge("%s.%s" % (metric_namespace, metric_name.lower()), value, tags=tags)
 
     def _submit_partition_lags(self, partition, tags):


### PR DESCRIPTION
Since Python 2 EOL is set for January 1, 2020, and the Datadog Agent 7 only ships with Python 3, we managed to get the Burrow checks up and running with only a few changes to adapt to Python 3 with Datadog Agent v7 (latest). 

Docker agent 7 shows no errors:

![image](https://user-images.githubusercontent.com/1352979/83569378-a8588280-a524-11ea-8fb8-c09af5d73a5f.png)


And `agent check burrow` returns no errors either:

![Screenshot 2020-06-02 at 22 53 02](https://user-images.githubusercontent.com/1352979/83569278-852dd300-a524-11ea-9959-c52e6d7cfd09.png)

However, I did not manage to get the local setup up and running. `magnetme/burrow` is 3 years old at least and crashes instantly for me locally.

Fixes #12 